### PR TITLE
Make sure to also escape quotes

### DIFF
--- a/src/compile/references.js
+++ b/src/compile/references.js
@@ -33,6 +33,9 @@ module.exports = function(Velocity, utils) {
         } else if (c === '<') {
           cstr = "&lt;"
           escape = true
+        } else if (c === '"') {
+          cstr = "&quot;"
+          escape = true
         } else if (c === '>') {
           cstr = "&gt;"
           escape = true


### PR DESCRIPTION
Imagine a case where a stringified json is inlined as a `data` attribute, in this case the `"` must be escaped, too, in order to maintain valid html